### PR TITLE
Fix bug in drift map path

### DIFF
--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -638,7 +638,12 @@ if __name__ == "__main__":
 
     # loop through block-streams
     for recording_name in recording_names:
+        recording_folder = postprocessed_folder / recording_name
+        if not recording_folder.is_dir():
+            print(f"\tSkipping sorting visualization for recording: {recording_name}")
+            continue
         print(f"Visualizing recording: {recording_name}")
+        
         if recording_name not in visualization_output:
             visualization_output[recording_name] = {}
 
@@ -777,10 +782,6 @@ if __name__ == "__main__":
                 print(f"Something wrong when visualizing timeseries: {e}")
 
         # sorting summary        
-        recording_folder = postprocessed_folder / recording_name
-        if not recording_folder.is_dir():
-            print(f"\tSkipping sorting visualization for recording: {recording_name}")
-            continue
         print(f"\tVisualizing sorting summary")        
         we = si.load_waveforms(recording_folder)
         sorting_precurated = si.load_extractor(results_folder / "sorting_precurated" / recording_name)

--- a/metadata/metadata.yml
+++ b/metadata/metadata.yml
@@ -1,5 +1,5 @@
 metadata_version: 1
-name: (stable) Ephys processing pipeline Kilosort2.5
+name: Ephys processing pipeline Kilosort2.5
 description: |-
   Electrophysiology analysis pipeline using Kilosort2.5 via SpikeInterface.
 

--- a/metadata/metadata.yml
+++ b/metadata/metadata.yml
@@ -1,5 +1,5 @@
 metadata_version: 1
-name: Ephys processing pipeline Kilosort2.5
+name: (stable) Ephys processing pipeline Kilosort2.5
 description: |-
   Electrophysiology analysis pipeline using Kilosort2.5 via SpikeInterface.
 


### PR DESCRIPTION
## Issue
Drift maps are mixed up: the data shown in each image does not match the recording specified in the filename

To illustrate, probe F was not inserted in this recording:

- time-series here shows correct data:
https://figurl.org/f?v=gs://figurl/spikesortingview-10&d=sha1://027df4f4421f78ee61ae4b3d794d15795474d69c&label=ecephys_664438_2023-04-12_14-59-51%20-%20experiment1_Record%20Node%20102%23Neuropix-PXI-100.probeF-AP_recording1&zone=aind

- drift map shows incorrect data, from an inserted probe:
![experiment1_Record Node 102#Neuropix-PXI-100 probeF-AP_recording1_drift](https://user-images.githubusercontent.com/63425812/234425970-af724729-bc02-4c00-928a-47c8f9861652.png)

## Details
Loop variable `recording_folder` is used in Visualization section to get data for plotting.

Drift maps are generated before `recording_folder` is constructed on each iteration of the loop: so the drift map data is loaded using an incorrect, leftover value of `recording_folder` (from the last iteration of the preceding Curation loop, then from the previous iteration of Visualization loop)

Drift map fig paths are effectively circshifted by 1 recording: [fig1: recN, fig2: rec1, fig3: rec2 ... figN: recN-1]

## Fix
-> Move construction of `recording_folder` to top of visualization loop